### PR TITLE
backdoor: use proper errno on iopl failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = 'A pure-Rust library for VMware host-guest protocol ("VMXh backdoo
 [dependencies]
 cfg-if = "^0.1"
 libc = "^0.2"
+errno = "^0.2"
 log = "^0.4"
 thiserror = "^1.0"
 

--- a/src/backdoor.rs
+++ b/src/backdoor.rs
@@ -75,7 +75,8 @@ impl BackdoorGuard {
         let level = if acquire { 0b11 } else { 0b00 };
         let err = unsafe { libc::iopl(level) };
         if err != 0 {
-            return Err(format!("iopl failed, errno={}", err).into());
+            let err_code = errno::errno();
+            return Err(format!("iopl failed: {} (errno: {})", err_code, err_code.0).into());
         };
 
         Ok(())


### PR DESCRIPTION
This changes the backdoor error handling logic to use the real errno
(instead of the negative return value) when iopl fails.