### PR TITLE
backdoor: allow avoiding iopl permission errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmw_backdoor"
-version = "0.1.4-alpha.0"
+version = "0.2.0-alpha.0"
 authors = ["Luca BRUNO <luca.bruno@coreos.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/examples/check-backdoor.rs
+++ b/examples/check-backdoor.rs
@@ -5,7 +5,7 @@ fn main() {
     let is_vmw = vmw::is_vmware_cpu();
     println!("VMware CPU detected: {}.", is_vmw);
 
-    let mut backdoor = vmw::access_backdoor().unwrap();
+    let mut backdoor = vmw::access_backdoor_privileged().unwrap();
     println!("Raised I/O access to reach backdoor port.");
 
     let found = match backdoor.probe_vmware_backdoor() {

--- a/examples/get-guestinfo.rs
+++ b/examples/get-guestinfo.rs
@@ -14,7 +14,7 @@ fn main() {
         panic!("Hypervisor not present");
     }
 
-    let mut backdoor = vmw::probe_backdoor().unwrap();
+    let mut backdoor = vmw::probe_backdoor_privileged().unwrap();
     eprintln!("Got backdoor access.");
 
     let mut erpc = backdoor.open_enhanced_chan().unwrap();

--- a/examples/log.rs
+++ b/examples/log.rs
@@ -14,7 +14,7 @@ fn main() {
         panic!("Hypervisor not present");
     }
 
-    let mut backdoor = vmw::probe_backdoor().unwrap();
+    let mut backdoor = vmw::probe_backdoor_privileged().unwrap();
     eprintln!("Got backdoor access.");
 
     let mut erpc = backdoor.open_enhanced_chan().unwrap();

--- a/examples/report-agent.rs
+++ b/examples/report-agent.rs
@@ -8,7 +8,7 @@ fn main() {
         panic!("Hypervisor not present");
     }
 
-    let mut backdoor = vmw::probe_backdoor().unwrap();
+    let mut backdoor = vmw::probe_backdoor_privileged().unwrap();
     eprintln!("Got backdoor access.");
 
     let mut erpc = backdoor.open_enhanced_chan().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! let is_vmw = vmw_backdoor::is_vmware_cpu();
 //! println!("VMware CPU detected: {}.", is_vmw);
 //!
-//! let mut guard = vmw_backdoor::access_backdoor().unwrap();
+//! let mut guard = vmw_backdoor::access_backdoor_privileged().unwrap();
 //! println!("Raised I/O access to reach backdoor port.");
 //!
 //! let found = guard.probe_vmware_backdoor().unwrap_or(false);
@@ -54,8 +54,11 @@ cfg_if::cfg_if! {
         mod erpc;
         mod low_bw;
 
-        pub use backdoor::{access_backdoor, probe_backdoor, BackdoorGuard};
         pub use asm::is_vmware_cpu;
+        pub use backdoor::{
+            access_backdoor, access_backdoor_privileged, probe_backdoor, probe_backdoor_privileged,
+            BackdoorGuard,
+        };
         pub use erpc::EnhancedChan;
     }
 }


### PR DESCRIPTION
This introduces additional methods for the backdoor-opening logic,
in order to allow consuming applications to keep going when changing
I/O access level is not allowed (see kernel_lockdown(7) on Linux).
In most cases the library may work without higher I/O level,
and actual failures can be handled via normal error-handling on RPC
methods.

Ref: https://github.com/lucab/vmw_backdoor-rs/issues/6