### PR TITLE
cargo: bump cfg-if dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/vmw_backdoor"
 description = 'A pure-Rust library for VMware host-guest protocol ("VMXh backdoor")'
 
 [dependencies]
-cfg-if = "^0.1"
+cfg-if = "^1.0"
 libc = "^0.2"
 errno = "^0.2"
 log = "^0.4"


### PR DESCRIPTION
This updates `cfg-if` to latest version.