### PR TITLE
cargo: update all URLs to new location

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,7 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: vmw_backdoor
-Source: https://www.github.com/lucab/vmw_backdoor
+Source: https://www.github.com/coreos/vmw_backdoor
 
 Files: *
-Copyright: 2017-2019, Project contributors
+Copyright: 2017-2022, Project contributors
 License: MIT or Apache-2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "vmw_backdoor"
 version = "0.2.2-alpha.0"
-authors = ["Luca BRUNO <luca.bruno@coreos.com>"]
+authors = ["Luca BRUNO <lucab@lucabruno.net>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
-repository = "https://github.com/lucab/vmw_backdoor-rs"
+repository = "https://github.com/coreos/vmw_backdoor-rs"
 documentation = "https://docs.rs/vmw_backdoor"
 description = 'A pure-Rust library for VMware host-guest protocol ("VMXh backdoor")'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # vmw\_backdoor
 
-[![Build Status](https://travis-ci.com/lucab/vmw_backdoor-rs.svg?branch=master)](https://travis-ci.com/lucab/vmw_backdoor-rs)
 [![crates.io](https://img.shields.io/crates/v/vmw_backdoor.svg)](https://crates.io/crates/vmw_backdoor)
 [![Documentation](https://docs.rs/vmw_backdoor/badge.svg)](https://docs.rs/vmw_backdoor)
 


### PR DESCRIPTION
This updates all metadata in order to stop pointing to the old repository location.