### PR TITLE
Release 0.2.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ thiserror = "^1.0"
 cc = "^1.0"
 
 [package.metadata.release]
-disable-publish = true
-disable-push = true
 post-release-commit-message = "cargo: development version bump"
 pre-release-commit-message = "cargo: release {{version}}"
+publish = false
+push = false
 sign-commit = true
 sign-tag = true
 tag-message = "release {{version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmw_backdoor"
-version = "0.2.2-alpha.0"
+version = "0.2.3"
 authors = ["Luca BRUNO <lucab@lucabruno.net>"]
 edition = "2018"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Note: I made a mistake when preparing this PR, so 0.2.2 is a non-existing faulty release that I had to [yank](https://crates.io/crates/vmw_backdoor/0.2.2). Thus this skips directly to 0.2.3.

---

Changes:
 * cargo: update all URLs to new location
 * cargo: update cargo-release metadata