### PR TITLE
cargo.toml: update to `errno 0.3^`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = 'A pure-Rust library for VMware host-guest protocol ("VMXh backdoo
 [dependencies]
 cfg-if = "^1.0"
 libc = "^0.2"
-errno = "^0.2"
+errno = "^0.3"
 log = "^0.4"
 thiserror = "^1.0"
 


### PR DESCRIPTION
change errno's version range from 0.2^ to 0.3^ work around the dependency issue found https://github.com/coreos/cargo-vendor-filterer/issues/71 which is effecting afterburn's vender tarball and consequently RCOS/C9s releases